### PR TITLE
KomaListクラスのgetKomaFromPlace()メソッドを追加する

### DIFF
--- a/KomaList.pde
+++ b/KomaList.pde
@@ -36,4 +36,10 @@ class KomaList {
     }
     return null;
   }
+  AbstractKoma getKomaFromPlace(int x, int y) {
+    for (AbstractKoma k : this.komaArray) {
+      if (x == k.x && y == k.y && k.kStat.active) return k;
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
getKomaFromPlace()メソッドでは，座標(x,y)に存在するコマがあるときに，そのコマのインスタンスを返す(無い場合はnullを返す)．